### PR TITLE
MAINT: browse_github_pat to create_github_token

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -44,7 +44,7 @@ check_global_git <- function(){
         warning("All rOpenSci package review is conducted through GitHub.
              To enable correct detection of your GitHub username,
              a PAT, Personal Authorisation Token, needs to be set up. \n
-             Use `usethis::browse_github_pat` to generate a PAT. \n
+             Use `usethis::create_github_token` to generate a PAT. \n
              Use `usethis::edit_r_environ` to store it as environment variable
              GITHUB_PAT or GITHUB_TOKEN in your .Renviron file. \n
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ remotes::install_github("ropensci-org/pkgreviewr")
 Because rOpenSci reviews are conducted through github repository [`ropensci/software-review`](https://github.com/ropensci/software-review), **`pkgreviewr` uses your GitHub username to prepopulate various fields in the review project files**.
 
 To detect your username correctly, a PAT, Personal Authorisation Token, needs to be set up.
-You can use `usethis::browse_github_pat()` to generate a PAT and `usethis::edit_r_environ()` to store it as environment variable `GITHUB_PAT` or `GITHUB_TOKEN` in your .`Renviron` file. For more info, see article on publishing review on GitHub in pkgreviewr documentation.
+You can use `usethis::create_github_token()` to generate a PAT and `usethis::edit_r_environ()` to store it as environment variable `GITHUB_PAT` or `GITHUB_TOKEN` in your .`Renviron` file. For more info, see article on publishing review on GitHub in pkgreviewr documentation.
 
 If you do not have a PAT set up, you will receive an warning and any fields related to your GitHub username will not be correctly populated. However, this shouldn't affect your ability to complete your review. 
 

--- a/vignettes/publish-review-on-github.Rmd
+++ b/vignettes/publish-review-on-github.Rmd
@@ -48,7 +48,7 @@ Currently we've not integrated the creation of an remote GitHub repo but we're e
 
 To use `usethis::use_github`, you'll need to supply a **github personal access token (PAT) token**. The easiest way to set it up for all your r workflows is to store you PAT in a `GITHUB_PAT` system variable in your [.Renviron](https://csgillespie.github.io/efficientR/3-3-r-startup.html#renviron) dotfile.  To do this:
 
-1. **Generate PAT**: use `usethis::browse_github_pat` to launch page to generate a PAT on GitHub.
+1. **Generate PAT**: use `usethis::create_github_token` to launch page to generate a PAT on GitHub.
 
 2. **[Add PAT to your `.Renviron`](https://github.com/jennybc/happy-git-with-r/blob/master/81_github-api-tokens.Rmd) dot file**: Use `usethis::edit_r_environ()` to open your user level `.Renviron`, paste the copied PAT token from github and save it like so:
 


### PR DESCRIPTION
To deal with the fact that:

```R
usethis::browse_github_pat()
Error:
! `browse_github_pat()` was deprecated in usethis 2.0.0 and is now defunct.
ℹ Please use `create_github_token()` instead.
```